### PR TITLE
Refactor captcha validation to remove verbose conditionals

### DIFF
--- a/lib/devise-security/controllers/helpers.rb
+++ b/lib/devise-security/controllers/helpers.rb
@@ -21,6 +21,11 @@ module DeviseSecurity
         end
       end
 
+      def valid_captcha_if_defined?(captcha)
+        defined?(verify_recaptcha) && verify_recaptcha ||
+          defined?(valid_captcha?) && valid_captcha?(captcha)
+      end
+
       # controller instance methods
 
         private
@@ -88,9 +93,6 @@ module DeviseSecurity
         def ignore_password_expire?
           false
         end
-
-
     end
   end
-
 end

--- a/lib/devise-security/patches/confirmations_controller_captcha.rb
+++ b/lib/devise-security/patches/confirmations_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurity::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if valid_captcha_if_defined?(params[:captcha])
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 
           if successfully_sent?(resource)

--- a/lib/devise-security/patches/controller_captcha.rb
+++ b/lib/devise-security/patches/controller_captcha.rb
@@ -7,8 +7,9 @@ module DeviseSecurity::Patches
     end
 
     private
+
     def check_captcha
-      return if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+      return if valid_captcha_if_defined?(params[:captcha])
 
       flash[:alert] = t('devise.invalid_captcha') if is_navigational_format?
       respond_with({}, location: url_for(action: :new))

--- a/lib/devise-security/patches/passwords_controller_captcha.rb
+++ b/lib/devise-security/patches/passwords_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurity::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if valid_captcha_if_defined?(params[:captcha])
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise-security/patches/registrations_controller_captcha.rb
+++ b/lib/devise-security/patches/registrations_controller_captcha.rb
@@ -5,7 +5,7 @@ module DeviseSecurity::Patches
       define_method :create do |&block|
         build_resource(sign_up_params)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if valid_captcha_if_defined?(params[:captcha])
           if resource.save
             block.call(resource) if block
             if resource.active_for_authentication?

--- a/lib/devise-security/patches/sessions_controller_captcha.rb
+++ b/lib/devise-security/patches/sessions_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurity::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do |&block|
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if valid_captcha_if_defined?(params[:captcha])
           self.resource = warden.authenticate!(auth_options)
           set_flash_message(:notice, :signed_in) if is_flashing_format?
           sign_in(resource_name, resource)

--- a/lib/devise-security/patches/unlocks_controller_captcha.rb
+++ b/lib/devise-security/patches/unlocks_controller_captcha.rb
@@ -3,7 +3,7 @@ module DeviseSecurity::Patches
     extend ActiveSupport::Concern
     included do
       define_method :create do
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha]))
+        if valid_captcha_if_defined?(params[:captcha])
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise-security/patches/unlocks_controller_security_question.rb
+++ b/lib/devise-security/patches/unlocks_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) ||
+        if valid_captcha_if_defined?(params[:captcha]) ||
            (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)


### PR DESCRIPTION
This changes the conditionals is the `*_controller_captcha.rb`s to remove some of the duplication of checking if the captcha is defined and valid. It makes the controllers a bit more readable.

This can also be applied to checking if the security question is defined and correct in the `*_controller_security_question.rb`s.