### PR TITLE
Updated minimum devise version.

### DIFF
--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   else
     s.add_runtime_dependency 'railties', '>= 3.2.6', '< 6.0'
   end
-  s.add_runtime_dependency 'devise', '>= 3.0.0', '< 5.0'
+  s.add_runtime_dependency 'devise', '>= 4.2.0', '< 5.0'
   s.add_development_dependency 'bundler', '>= 1.3.0', '< 2.0'
   s.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.10'
   s.add_development_dependency 'rubocop', '~> 0'


### PR DESCRIPTION
bypass_sign_in wasn't added until the 4.2.0 release.