### PR TITLE
Remove compound conditionals

### DIFF
--- a/lib/devise-security/controllers/helpers.rb
+++ b/lib/devise-security/controllers/helpers.rb
@@ -26,6 +26,11 @@ module DeviseSecurity
           defined?(valid_captcha?) && valid_captcha?(captcha)
       end
 
+      def valid_security_question_answer?(resource, answer)
+        resource.security_question_answer.present? &&
+          resource.security_question_answer == answer
+      end
+
       # controller instance methods
 
         private

--- a/lib/devise-security/controllers/helpers.rb
+++ b/lib/devise-security/controllers/helpers.rb
@@ -21,6 +21,11 @@ module DeviseSecurity
         end
       end
 
+      def valid_captcha_or_security_question?(resource, params)
+        valid_captcha_if_defined?(params[:captcha]) ||
+          valid_security_question_answer?(resource, params[:security_question_answer])
+      end
+
       def valid_captcha_if_defined?(captcha)
         defined?(verify_recaptcha) && verify_recaptcha ||
           defined?(valid_captcha?) && valid_captcha?(captcha)

--- a/lib/devise-security/patches/confirmations_controller_security_question.rb
+++ b/lib/devise-security/patches/confirmations_controller_security_question.rb
@@ -6,8 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if valid_captcha_if_defined?(params[:captcha]) ||
-           (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
+        if valid_captcha_if_defined?(params[:captcha]) || valid_security_question_answer?(resource, params[:security_question_answer])
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 
           if successfully_sent?(resource)

--- a/lib/devise-security/patches/confirmations_controller_security_question.rb
+++ b/lib/devise-security/patches/confirmations_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if valid_captcha_if_defined?(params[:captcha]) || valid_security_question_answer?(resource, params[:security_question_answer])
+        if valid_captcha_or_security_question?(resource, params)
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 
           if successfully_sent?(resource)

--- a/lib/devise-security/patches/confirmations_controller_security_question.rb
+++ b/lib/devise-security/patches/confirmations_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) ||
+        if valid_captcha_if_defined?(params[:captcha]) ||
            (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_confirmation_instructions(params[resource_name])
 

--- a/lib/devise-security/patches/controller_security_question.rb
+++ b/lib/devise-security/patches/controller_security_question.rb
@@ -10,7 +10,7 @@ module DeviseSecurity::Patches
     def check_security_question
       # only find via email, not login
       resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
-      return if (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
+      return if valid_security_question_answer?(resource, params[:security_question_answer])
 
       flash[:alert] = t('devise.invalid_security_question') if is_navigational_format?
       respond_with({}, location: url_for(action: :new))

--- a/lib/devise-security/patches/passwords_controller_security_question.rb
+++ b/lib/devise-security/patches/passwords_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if valid_captcha_if_defined?(params[:captcha]) || valid_security_question_answer?(resource, params[:security_question_answer])
+        if valid_captcha_or_security_question?(resource, params)
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise-security/patches/passwords_controller_security_question.rb
+++ b/lib/devise-security/patches/passwords_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if ((defined? verify_recaptcha) && (verify_recaptcha)) || ((defined? valid_captcha?) && (valid_captcha? params[:captcha])) ||
+        if valid_captcha_if_defined?(params[:captcha]) ||
            (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)

--- a/lib/devise-security/patches/passwords_controller_security_question.rb
+++ b/lib/devise-security/patches/passwords_controller_security_question.rb
@@ -6,8 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if valid_captcha_if_defined?(params[:captcha]) ||
-           (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
+        if valid_captcha_if_defined?(params[:captcha]) || valid_security_question_answer?(resource, params[:security_question_answer])
           self.resource = resource_class.send_reset_password_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise-security/patches/unlocks_controller_security_question.rb
+++ b/lib/devise-security/patches/unlocks_controller_security_question.rb
@@ -6,7 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if valid_captcha_if_defined?(params[:captcha]) || valid_security_question_answer?(resource, params[:security_question_answer])
+        if valid_captcha_or_security_question?(resource, params)
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))

--- a/lib/devise-security/patches/unlocks_controller_security_question.rb
+++ b/lib/devise-security/patches/unlocks_controller_security_question.rb
@@ -6,8 +6,7 @@ module DeviseSecurity::Patches
         # only find via email, not login
         resource = resource_class.find_or_initialize_with_error_by(:email, params[resource_name][:email], :not_found)
 
-        if valid_captcha_if_defined?(params[:captcha]) ||
-           (resource.security_question_answer.present? && resource.security_question_answer == params[:security_question_answer])
+        if valid_captcha_if_defined?(params[:captcha]) || valid_security_question_answer?(resource, params[:security_question_answer])
           self.resource = resource_class.send_unlock_instructions(params[resource_name])
           if successfully_sent?(resource)
             respond_with({}, :location => new_session_path(resource_name))


### PR DESCRIPTION
Similar to an [earlier PR](https://github.com/devise-security/devise-security/pull/6) on the same subject.

This removes the duplicated checking of the security question's answer. In 3 places, it combines the checking for valid captchas and correct security question answer into a single method check to a new helper method. I think it improves readability a bit.

(This also adds the `valid_captcha_if_defined?` check in 2 places I missed in the earlier PR :see_no_evil: )