### PR TITLE
Update Password Archivable to use password_salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ create_table :old_passwords do |t|
   t.string :encrypted_password, :null => false
   t.string :password_archivable_type, :null => false
   t.integer :password_archivable_id, :null => false
+  t.string :password_salt
   t.datetime :created_at
 end
 add_index :old_passwords, [:password_archivable_type, :password_archivable_id], :name => :index_password_archivable


### PR DESCRIPTION
We need to add password_salt on migration because we get an error if we don't include this column.