### PR TITLE
Avoid crash if resource model's encrypted_password column is NULL

### DIFF
--- a/lib/devise-security/models/password_archivable.rb
+++ b/lib/devise-security/models/password_archivable.rb
@@ -58,7 +58,7 @@ module Devise
 
       # archive the last password before save and delete all to old passwords from archive
       def archive_password
-        if encrypted_password_changed?
+        if encrypted_password_changed? && encrypted_password_change.first.present?
           if archive_count.to_i > 0
             old_passwords.create! old_password_params
             old_passwords.order(:id).reverse_order.offset(archive_count).destroy_all

--- a/test/dummy/db/migrate/20120508165529_create_tables.rb
+++ b/test/dummy/db/migrate/20120508165529_create_tables.rb
@@ -6,7 +6,7 @@ class CreateTables < MIGRATION_CLASS
 
       ## Database authenticatable
       t.string :email,              null: false, default: ''
-      t.string :encrypted_password, null: false, default: ''
+      t.string :encrypted_password, null: true, default: ''
 
       t.datetime :password_changed_at
       t.timestamps null: false

--- a/test/dummy/db/migrate/20120508165529_create_tables.rb
+++ b/test/dummy/db/migrate/20120508165529_create_tables.rb
@@ -6,7 +6,7 @@ class CreateTables < MIGRATION_CLASS
 
       ## Database authenticatable
       t.string :email,              null: false, default: ''
-      t.string :encrypted_password, null: true, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       t.datetime :password_changed_at
       t.timestamps null: false

--- a/test/test_password_archivable.rb
+++ b/test/test_password_archivable.rb
@@ -21,6 +21,12 @@ class TestPasswordArchivable < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordInvalid) { set_password(user,  'password1') }
   end
 
+  test 'does not save an OldPassword if user password was originally nil' do
+    user = User.create password: nil, password_confirmation: nil
+    set_password(user, 'password1')
+    assert_equal 0, OldPassword.count
+  end
+
   test 'cannot use archived passwords' do
     assert_equal 2, Devise.password_archiving_count
 


### PR DESCRIPTION
Although by default, Devise [generates](https://github.com/plataformatec/devise/blob/master/lib/generators/active_record/devise_generator.rb) migrations for an `encrypted_password` column that is `NOT NULL`, there are situations in which the column _is_ `NULL`. For instance, the documentation in the `devise_invitable` gem [explicitly requires](https://github.com/scambra/devise_invitable#activerecord-migration) developers using their gem to make that column `NULL`.

So, it's not safe to assume `encrypted_password` is always `NOT NULL`. In the use case where a user is created without a password, and then chooses one, a crash will be caused because `PasswordArchivable` attempts to create an `OldPassword` record with a null `encrypted_password`.

The changes in this PR simply make `PasswordArchivable` check before saving an `OldPassword` to make sure the previous password was not nil (and also introduces an associated test).