### PR TITLE
Documentation for initializer config file improved

### DIFF
--- a/lib/generators/templates/devise-security.rb
+++ b/lib/generators/templates/devise-security.rb
@@ -13,7 +13,11 @@ Devise.setup do |config|
   # How many passwords to keep in archive
   # config.password_archiving_count = 5
 
-  # Deny old password (true, false, count)
+  # Deny old passwords (true, false, number_of_old_passwords_to_check)
+  # Examples:
+  # config.deny_old_passwords = false # allow old passwords
+  # config.deny_old_passwords = true # will deny all the old passwords
+  # config.deny_old_passwords = 3 # will deny new passwords that matches with the last 3 passwords
   # config.deny_old_passwords = true
 
   # enable email validation for :secure_validatable. (true, false, validation_options)


### PR DESCRIPTION
Hi!

I think that my change regarding the `deny_old_passwords` configuration paramenter can help other people when configuring this gem.

A member of my team got confused with the old documentation and though that the value should be a `:count` symbol and not the number of old passwords to be tested :P .