### PR TITLE
pin rmagick & adjust travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,23 @@ rvm:
   - 2.6
   - ruby-head
 matrix:
-  allow_failures:
-    - rvm: ruby-head
+  exclude:
+    # Skip these combinations because they have incompatible dependencies
+    # and will always fail.
     - rvm: 2.6
       gemfile: gemfiles/rails_4.2_stable.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_4.2_stable.gemfile
     - rvm: 2.3
-      gemfile: gemfiles/rails_6.0.gemfile
+      gemfile: gemfiles/rails_6.0_beta.gemfile
     - rvm: 2.4
-      gemfile: gemfiles/rails_6.0.gemfile
+      gemfile: gemfiles/rails_6.0_beta.gemfile
+  allow_failures:
+    - rvm: ruby-head
+    - gemfile: gemfiles/rails_6.0_beta.gemfile
 gemfile:
   - gemfiles/rails_4.2_stable.gemfile
   - gemfiles/rails_5.0_stable.gemfile
   - gemfiles/rails_5.1_stable.gemfile
   - gemfiles/rails_5.2_stable.gemfile
-  - gemfiles/rails_6.0.gemfile
+  - gemfiles/rails_6.0_beta.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,49 +1,19 @@
 appraise 'rails-4.2-stable' do
-  gem 'sqlite3', '~> 1.3.0'
-  gem 'omniauth'
   gem 'rails', '~> 4.2.0'
-
-  group :development do
-    gem 'wwtd'
-  end
 end
 
 appraise 'rails-5.0-stable' do
-  gem 'sqlite3', '~> 1.3.0'
-  gem 'omniauth'
   gem 'rails', '~> 5.0.0'
-
-  group :development do
-    gem 'wwtd'
-  end
 end
 
 appraise 'rails-5.1-stable' do
-  gem 'sqlite3', '~> 1.3.0'
-  gem 'omniauth'
   gem 'rails', '~> 5.1.0'
-
-  group :development do
-    gem 'wwtd'
-  end
 end
 
 appraise 'rails-5.2-stable' do
-  gem 'sqlite3', '~> 1.3.0'
-  gem 'omniauth'
   gem 'rails', '~> 5.2.0'
-
-  group :development do
-    gem 'wwtd'
-  end
 end
 
-appraise 'rails-6.0' do
-  gem 'sqlite3', '~> 1.3.0'
-  gem 'omniauth'
+appraise 'rails-6.0-beta' do
   gem 'rails', '~> 6.0.0.beta1'
-
-  group :development do
-    gem 'wwtd'
-  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source "https://rubygems.org"
 gemspec
+gem 'bundler', '< 2'
 gem 'omniauth'
-gem 'sqlite3', '~> 1.3.0'
+gem 'rmagick', '< 3'
+
 group :development do
   gem 'wwtd'
+end
+
+group :active_record do
+  gem 'sqlite3', '~> 1.3.0'
 end

--- a/gemfiles/rails_4.2_stable.gemfile
+++ b/gemfiles/rails_4.2_stable.gemfile
@@ -2,12 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "bundler", "< 2"
 gem "omniauth"
-gem "sqlite3", "~> 1.3.0"
+gem "rmagick", "< 3"
 gem "rails", "~> 4.2.0"
 
 group :development do
   gem "wwtd"
+end
+
+group :active_record do
+  gem "sqlite3", "~> 1.3.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0_stable.gemfile
+++ b/gemfiles/rails_5.0_stable.gemfile
@@ -2,12 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "bundler", "< 2"
 gem "omniauth"
-gem "sqlite3", "~> 1.3.0"
+gem "rmagick", "< 3"
 gem "rails", "~> 5.0.0"
 
 group :development do
   gem "wwtd"
+end
+
+group :active_record do
+  gem "sqlite3", "~> 1.3.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1_stable.gemfile
+++ b/gemfiles/rails_5.1_stable.gemfile
@@ -2,12 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "bundler", "< 2"
 gem "omniauth"
-gem "sqlite3", "~> 1.3.0"
+gem "rmagick", "< 3"
 gem "rails", "~> 5.1.0"
 
 group :development do
   gem "wwtd"
+end
+
+group :active_record do
+  gem "sqlite3", "~> 1.3.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2_stable.gemfile
+++ b/gemfiles/rails_5.2_stable.gemfile
@@ -2,12 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "bundler", "< 2"
 gem "omniauth"
-gem "sqlite3", "~> 1.3.0"
+gem "rmagick", "< 3"
 gem "rails", "~> 5.2.0"
 
 group :development do
   gem "wwtd"
+end
+
+group :active_record do
+  gem "sqlite3", "~> 1.3.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0_beta.gemfile
+++ b/gemfiles/rails_6.0_beta.gemfile
@@ -2,12 +2,17 @@
 
 source "https://rubygems.org"
 
+gem "bundler", "< 2"
 gem "omniauth"
-gem "sqlite3", "~> 1.3.0"
+gem "rmagick", "< 3"
 gem "rails", "~> 6.0.0.beta1"
 
 group :development do
   gem "wwtd"
+end
+
+group :active_record do
+  gem "sqlite3", "~> 1.3.0"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
rmagick released a new version recently that fails to install on travis.  This branch pins to a lower version until that can be resolved.

I also cleaned up the travis configs a bit so that it does not perform unnecessary builds.