### PR TITLE
Load Compatibility when using session limitable

### DIFF
--- a/lib/devise-security/models/session_limitable.rb
+++ b/lib/devise-security/models/session_limitable.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'compatibility'
 require 'devise-security/hooks/session_limitable'
 
 module Devise
@@ -11,7 +12,8 @@ module Devise
     # someone used his credentials to sign in.
     module SessionLimitable
       extend ActiveSupport::Concern
-
+      include Devise::Models::Compatibility
+      
       # Update the unique_session_id on the model.  This will be checked in
       # the Warden after_set_user hook in {file:devise-security/hooks/session_limitable}
       # @param unique_session_id [String]

--- a/lib/devise-security/models/session_limitable.rb
+++ b/lib/devise-security/models/session_limitable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'compatibility'
+require_relative 'compatibility'
 require 'devise-security/hooks/session_limitable'
 
 module Devise
@@ -13,7 +13,7 @@ module Devise
     module SessionLimitable
       extend ActiveSupport::Concern
       include Devise::Models::Compatibility
-      
+
       # Update the unique_session_id on the model.  This will be checked in
       # the Warden after_set_user hook in {file:devise-security/hooks/session_limitable}
       # @param unique_session_id [String]

--- a/test/test_session_limitable.rb
+++ b/test/test_session_limitable.rb
@@ -2,6 +2,15 @@ require 'test_helper'
 
 class TestSessionLimitable < ActiveSupport::TestCase
 
+  class SessionLimitableUser < User
+    devise :session_limitable
+    include ::Mongoid::Mappings if DEVISE_ORM == :mongoid
+  end
+
+  test 'includes Devise::Models::Compatibility' do
+    assert_kind_of(Devise::Models::Compatibility, SessionLimitableUser.new)
+  end
+
   test '#update_unique_session_id!(value) updates valid record' do
     user = User.create! password: 'passWord1', password_confirmation: 'passWord1', email: 'bob@microsoft.com'
     assert user.persisted?


### PR DESCRIPTION
Models loading session limitable, but not one of the other features that 
load the compatibility layer would have missing methods becuase the ORM 
compatibility methods were not loaded.

Fixes #106