### PR TITLE
Use better german translation for symbol

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -11,8 +11,8 @@ de:
           one: muss mindestens einen Kleinbuchstaben enthalten
           other: muss mindestens %{count} Kleinbuchstaben enthalten
         symbol:
-          one: muss mindestens ein Satzzeichen enthalten
-          other: muss mindestens %{count} Satzzeichen enthalten
+          one: muss mindestens ein Sonderzeichen enthalten
+          other: muss mindestens %{count} Sonderzeichen enthalten
         upper:
           one: muss mindestens einen Großbuchstaben enthalten
           other: muss mindestens %{count} Großbuchstaben enthalten


### PR DESCRIPTION
Use a german translation that fits better.
You can translate "Satzzeichen" with punctuation. Common use in german is "Sonderzeichen" in case of passwords.