### PR TITLE
handle password confirmation mismatched

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,6 +1,7 @@
 de:
   errors:
     messages:
+      password_confirmation_mismatched: 'nicht übereinstimmend.'
       taken_in_past: 'wurde bereits in der Vergangenheit verwendet.'
       equal_to_current_password: 'darf nicht dem aktuellen Passwort entsprechen.'
       password_complexity:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   errors:
     messages:
+      password_confirmation_mismatched: 'mismatched.'
       taken_in_past: 'was used previously.'
       equal_to_current_password: 'must be different than the current password.'
       password_complexity:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,7 @@
 es:
   errors:
     messages:
+      password_confirmation_mismatched: 'no coinciden.'
       taken_in_past: 'la contraseña fue usada previamente, favor elegir otra.'
       equal_to_current_password: 'tiene que ser diferente a la contraseña actual.'
       password_complexity:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,6 +1,7 @@
 fr:
   errors:
     messages:
+      password_confirmation_mismatched: 'non corrispondenti.'
       taken_in_past: a été utilisé trop récemment. Veuillez en choisir un autre
       equal_to_current_password: doit être différent de l'actuel
       password_complexity:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,6 +1,7 @@
 it:
   errors:
     messages:
+      password_confirmation_mismatched: 'mal assorti!'
       taken_in_past: "e' stata gia' utilizzata in passato!"
       equal_to_current_password: " deve essere differente dalla password corrente!"
   devise:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,7 @@
 ja:
   errors:
     messages:
+      password_confirmation_mismatched: '不一致。'
       taken_in_past: 'は既に使われています。'
       equal_to_current_password: 'は現在のパスワードと異なるものである必要があります。'
       password_complexity:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,6 +1,7 @@
 ru:
   errors:
     messages:
+      password_confirmation_mismatched: 'несовместимый'
       taken_in_past: 'уже ранее использовался.'
       equal_to_current_password: 'должен отличаться от текущего пароля.'
       password_complexity:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,6 +1,7 @@
 tr:
   errors:
     messages:
+      password_confirmation_mismatched: 'eşleşmeyen.'
       taken_in_past: "daha önce kullanıldı."
       equal_to_current_password: "mevcut paroladan farklı olmalı."
       password_format: "büyük, küçük harfler ve sayılar içermeli."

--- a/lib/devise-security/models/database_authenticatable_patch.rb
+++ b/lib/devise-security/models/database_authenticatable_patch.rb
@@ -9,14 +9,21 @@ module Devise
         new_password = params[:password]
         new_password_confirmation = params[:password_confirmation]
 
-        result = if valid_password?(current_password) && new_password.present? && new_password_confirmation.present?
+        result = if valid_password?(current_password) && new_password.present? && new_password_confirmation.present? && new_password_confirmation == new_password
           update(params, *options)
         else
           self.assign_attributes(params, *options)
           self.valid?
           self.errors.add(:current_password, current_password.blank? ? :blank : :invalid)
           self.errors.add(:password, new_password.blank? ? :blank : :invalid)
-          self.errors.add(:password_confirmation, new_password_confirmation.blank? ? :blank : :invalid)
+          new_password_confirmation_error = if new_password_confirmation.blank?
+                                              :blank
+                                            elsif new_password != new_password_confirmation
+                                              I18n.t('errors.messages.password_confirmation_mismatched')
+                                            else
+                                              :invalid
+                                            end
+          self.errors.add(:password_confirmation, new_password_confirmation_error)
           false
         end
 


### PR DESCRIPTION
At the moment, when the password expires and user is taken to new password page.  If the user types in two different passwords in `New Password` and `Confirm Password` the code does check if these two match or not. 

This pull request solves this issue. Cheers !