### PR TITLE
Fixes/documentation for password complexity validator

### DIFF
--- a/lib/devise-security/validators/password_complexity_validator.rb
+++ b/lib/devise-security/validators/password_complexity_validator.rb
@@ -3,17 +3,19 @@
 # Password complexity validator
 # Options:
 # - digit:  minimum number of digits in the validated string
+# - digits: minimum number of digits in the validated string
 # - lower:  minimum number of lower-case letters in the validated string
 # - symbol: minimum number of punctuation characters or symbols in the validated string
+# - symbols: minimum number of punctuation characters or symbols in the validated string
 # - upper:  minimum number of upper-case letters in the validated string
 class DeviseSecurity::PasswordComplexityValidator < ActiveModel::EachValidator
   PATTERNS = {
     digit: /\p{Digit}/,
     digits: /\p{Digit}/,
     lower: /\p{Lower}/,
-    upper: /\p{Upper}/,
     symbol: /\p{Punct}|\p{S}/,
-    symbols: /\p{Punct}|\p{S}/
+    symbols: /\p{Punct}|\p{S}/,
+    upper: /\p{Upper}/
   }.freeze
 
   def validate_each(record, attribute, value)

--- a/test/test_complexity_validator.rb
+++ b/test/test_complexity_validator.rb
@@ -37,6 +37,12 @@ class PasswordComplexityValidatorTest < Minitest::Test
     assert(ModelWithPassword.new('aaa1').valid?)
   end
 
+  def test_enforces_digits
+    ModelWithPassword.validates :password, 'devise_security/password_complexity': { digits: 2 }
+    refute(ModelWithPassword.new('aaa1').valid?)
+    assert(ModelWithPassword.new('aa12').valid?)
+  end
+
   def test_enforces_lower
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { lower: 1 }
     refute(ModelWithPassword.new('AAAA').valid?)
@@ -47,6 +53,12 @@ class PasswordComplexityValidatorTest < Minitest::Test
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { symbol: 1 }
     refute(ModelWithPassword.new('aaaa').valid?)
     assert(ModelWithPassword.new('aaa!').valid?)
+  end
+
+  def test_enforces_symbols
+    ModelWithPassword.validates :password, 'devise_security/password_complexity': { symbols: 2 }
+    refute(ModelWithPassword.new('aaa!').valid?)
+    assert(ModelWithPassword.new('aa!?').valid?)
   end
 
   def test_enforces_combination


### PR DESCRIPTION
Hi there, 

I realized that `DeviseSecurity::PasswordComplexityValidator` was missing a couple of options in its documentation. 

So here is a PR to complete the list of options in the documentation. Also, there are a couple of changes to test the behavior with `digits` and `symbols`.

I hope it helps! 👍 

Thanks,
Ernesto 