### PR TITLE
Correct typo in error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
           other: must contain at least %{count} lower-case letters
         symbol:
           one: must contain at least one punctuation mark or symbol
-          other: must contain at least %{count} puncutation marks or symbols
+          other: must contain at least %{count} punctuation marks or symbols
         upper:
           one: must contain at least one upper-case letter
           other: must contain at least %{count} upper-case letters


### PR DESCRIPTION
Hi there,

This is a small pull request to fix a typo in `en.yml`. Please check it out. 

Thanks! 

