### PR TITLE
Simpler valid email for PasswordExpiredControllerTest

### DIFF
--- a/test/controllers/test_password_expired_controller.rb
+++ b/test/controllers/test_password_expired_controller.rb
@@ -8,9 +8,9 @@ class Devise::PasswordExpiredControllerTest < ActionController::TestCase
   setup do
     @controller.class.respond_to :json, :xml
     @request.env["devise.mapping"] = Devise.mappings[:user]
-    @user = User.create!(
+    @user = User.create(
       username: 'hello',
-      email: 'hello@path.travel',
+      email: 'bob@microsoft.com',
       password: 'Password4',
       password_changed_at: 4.months.ago,
       confirmed_at: 5.months.ago


### PR DESCRIPTION
After initial test suite run before doing another PR - so without any changes - I run into the issue of a failing test in PasswordExpiredControllerTest because of the used email for user. Since the aim of this specific test is not the email-validator, I thought it would be a good idea to use a simpler email address there, so that future contributors wont run into the same issue.

I also changed `create!` to `create` so if the user validation fails, this test will fail on the assert instead of getting the raise from the invalid record on.