### PR TITLE
Allow random failures for unsupported Ruby/Rails pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,13 @@ matrix:
   allow_failures:
     # edge, not expected to pass
     - rvm: ruby-head
+    # not supported officially, might cause random failures
+    - rvm: 2.7
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 2.7
+      gemfile: gemfiles/rails_5.2.gemfile
 gemfile:
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile


### PR DESCRIPTION
While investigating random CI failures for this project, I noticed that this proejct is tested on Ruby 2.7.1 with Rails < 6, which is officially unsupported  (rails/rails#38426).

I think we should still add these version combinations to Travis CI's allow failures list, and hope this can make CI more stable.