### PR TITLE
Reduce gem size

### DIFF
--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   ]
   s.post_install_message = 'WARNING: devise-security will drop support for Rails 4.2 in version 0.16.0'
 
-  s.files         = Dir['README.md', 'LICENSE.txt', 'lib/**/*']
+  s.files         = Dir['README.md', 'LICENSE.txt', 'lib/**/*', 'app/**/*', 'config/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.3.0'

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   ]
   s.post_install_message = 'WARNING: devise-security will drop support for Rails 4.2 in version 0.16.0'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- test/*`.split("\n")
+  s.files         = Dir['README.md', 'LICENSE.txt', 'lib/**/*']
+  s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.3.0'
 


### PR DESCRIPTION
I'm working on docker optimisations for our app and trying to reduce the size of the gems we are using. Gem does not need to contain all of the files, so I reduced it. `test` folder is more than half of the whole gem.