### PR TITLE
Update devise-security.gemspec

### DIFF
--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['README.md', 'LICENSE.txt', 'lib/**/*', 'app/**/*', 'config/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_runtime_dependency 'devise', '>= 4.3.0', '< 5.0'
 


### PR DESCRIPTION
Ensure required ruby version matches what we officially support. Follow up to https://github.com/devise-security/devise-security/pull/189.