### PR TITLE
Lock omniauth to < 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ DEPENDENCIES
   minitest
   minitest-rails (~> 5.2.0)
   mongoid
-  omniauth
+  omniauth (< 2.0.0)
   pry-byebug
   pry-rescue
   rails-controller-testing (<= 1.0.4)

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'easy_captcha'
   s.add_development_dependency 'm'
   s.add_development_dependency 'minitest'
-  s.add_development_dependency 'omniauth'
+  s.add_development_dependency 'omniauth', '< 2.0.0'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'pry-rescue'
   s.add_development_dependency 'rails_email_validator'


### PR DESCRIPTION
Devise 4.7.3 has a soft-lock of using 1.x

See https://github.com/devise-security/devise-security/issues/267