### PR TITLE
Remove lock on omniauth since devise is now on 4.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ DEPENDENCIES
   minitest
   minitest-rails (~> 5.2.0)
   mongoid (~> 7.2)
-  omniauth (< 3.0.0)
+  omniauth
   pry-byebug
   pry-rescue
   rails-controller-testing

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'easy_captcha'
   s.add_development_dependency 'm'
   s.add_development_dependency 'minitest'
-  s.add_development_dependency 'omniauth', '< 3.0.0' # https://github.com/devise-security/devise-security/issues/267
+  s.add_development_dependency 'omniauth'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'pry-rescue'
   s.add_development_dependency 'rails_email_validator'


### PR DESCRIPTION
Closes https://github.com/devise-security/devise-security/issues/267

Follow-up to https://github.com/devise-security/devise-security/pull/313 because I accidentally closed it.