### PR TITLE
Add Rails as an explicit dependency

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 appraise 'rails-5.0' do
-  gem 'railties', '~> 5.0.0'
+  gem 'rails', '~> 5.0.0'
   gem 'minitest-rails', '~> 5.0.0'
 
   group :active_record do
@@ -15,7 +15,7 @@ appraise 'rails-5.0' do
 end
 
 appraise 'rails-5.1' do
-  gem 'railties', '~> 5.1.0'
+  gem 'rails', '~> 5.1.0'
   gem 'minitest-rails', '~> 5.1.0'
 
   group :mongoid do
@@ -25,7 +25,7 @@ appraise 'rails-5.1' do
 end
 
 appraise 'rails-5.2' do
-  gem 'railties', '~> 5.2.0'
+  gem 'rails', '~> 5.2.0'
   gem 'minitest-rails', '~> 5.2.0'
 
   group :mongoid do
@@ -35,7 +35,7 @@ appraise 'rails-5.2' do
 end
 
 appraise 'rails-6.0' do
-  gem 'railties', '~> 6.0.0'
+  gem 'rails', '~> 6.0.0'
   gem 'minitest-rails', '~> 6.0.0'
 
   group :mongoid do
@@ -45,7 +45,7 @@ appraise 'rails-6.0' do
 end
 
 appraise 'rails-6.1' do
-  gem 'railties', '~> 6.1.0'
+  gem 'rails', '~> 6.1.0'
   gem 'minitest-rails', '~> 6.1.0'
 
   group :mongoid do

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 # Oldest Rails version getting security patches is 5.2
 gem 'minitest-rails', '~> 5.2.0'
-gem 'railties', '~> 5.2.4'
 
 group :active_record do
   gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     devise-security (0.16.0)
       devise (>= 4.3.0, < 5.0)
+      rails (>= 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
 
   s.add_runtime_dependency 'devise', '>= 4.3.0', '< 5.0'
+  s.add_runtime_dependency 'rails', '>= 5.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'bundler'

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "minitest-rails", "~> 5.0.0"
-gem "railties", "~> 5.0.0"
+gem "rails", "~> 5.0.0"
 
 group :active_record do
   gem "sqlite3", "~> 1.3.0"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "minitest-rails", "~> 5.1.0"
-gem "railties", "~> 5.1.0"
+gem "rails", "~> 5.1.0"
 
 group :active_record do
   gem "sqlite3"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "minitest-rails", "~> 5.2.0"
-gem "railties", "~> 5.2.0"
+gem "rails", "~> 5.2.0"
 
 group :active_record do
   gem "sqlite3"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "minitest-rails", "~> 6.0.0"
-gem "railties", "~> 6.0.0"
+gem "rails", "~> 6.0.0"
 
 group :active_record do
   gem "sqlite3"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "minitest-rails", "~> 6.1.0"
-gem "railties", "~> 6.1.0"
+gem "rails", "~> 6.1.0"
 
 group :active_record do
   gem "sqlite3"


### PR DESCRIPTION
Closes https://github.com/devise-security/devise-security/issues/311

The testing architecture is dependent on Rails being present, so it was extremely hard to figure out how to include just the required sub-dependencies and ensure that the library still works.

We would have to rewrite the tests to 
A) not require a Rails dummy application 
B) manually load things like ActiveRecord database pooling. 

It's definitely possible, but a much larger project than I was anticipating.

Therefore, I decided to go ahead and require the entirety of Rails.