### PR TITLE
Add default_scoped to prevent deprecation exception

### DIFF
--- a/lib/devise-security/models/password_archivable.rb
+++ b/lib/devise-security/models/password_archivable.rb
@@ -47,7 +47,7 @@ module Devise
           # NOTE: we deliberately do not do mass assignment here so that users that
           #   rely on `protected_attributes_continued` gem can still use this extension.
           #   See issue #68
-          self.class.new.tap { |object| object.encrypted_password = old_password }.valid_password?(password)
+          self.class.default_scoped.new.tap { |object| object.encrypted_password = old_password }.valid_password?(password)
         end
       end
 


### PR DESCRIPTION
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create!` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `User.default_scoped`.