### PR TITLE
Add fix to ruby-head issue

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -42,6 +42,11 @@ appraise 'rails-6.0' do
     gem 'database_cleaner-mongoid', '~> 2.0'
     gem 'mongoid', '~> 7.0.5'
   end
+
+  # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+  # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
+  # Taken from https://github.com/rails/rails/pull/42366
+  gem "net-smtp", require: false
 end
 
 appraise 'rails-6.1' do
@@ -52,4 +57,9 @@ appraise 'rails-6.1' do
     gem 'database_cleaner-mongoid', '~> 2.0'
     gem 'mongoid', '~> 7.0.5'
   end
+
+  # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+  # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
+  # Taken from https://github.com/rails/rails/pull/42366
+  gem "net-smtp", require: false
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "minitest-rails", "~> 6.0.0"
 gem "railties", "~> 6.0.0"
+gem "net-smtp", require: false
 
 group :active_record do
   gem "sqlite3"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "minitest-rails", "~> 6.1.0"
 gem "railties", "~> 6.1.0"
+gem "net-smtp", require: false
 
 group :active_record do
   gem "sqlite3"


### PR DESCRIPTION
See the following:
* https://github.com/rails/rails/pull/42366
* https://github.com/mikel/mail/pull/1439
* https://bugs.ruby-lang.org/issues/17873

In essence, the net/smtp gem config was changed in ruby 3.1
and the mail gem needs to merge in their fix.