### PR TITLE
Update rubocop requirement from ~> 0.81 to ~> 0.83.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -43,7 +43,7 @@ checks:
 plugins:
  rubocop:
   enabled: true
-  channel: rubocop-0-81
+  channel: rubocop-0-83
  markdownlint:
   enabled: true
  brakeman:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,15 @@
 require:
   - rubocop-rails
+
 AllCops:
   Exclude:
     - Gemfile*
     - bin/*
-    - gemfiles/*
-    - test/**/*
+    - gemfiles/**/*
+    - vendor/bundle/**/*
+  # Automatically enables new cops so that we only have to add them to
+  # edit default behavior
+  NewCops: enable
 
 Rails:
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,8 +207,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    rubocop (0.81.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (0.83.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -285,7 +284,7 @@ DEPENDENCIES
   rails-controller-testing
   rails_email_validator
   railties (~> 5.2.6)
-  rubocop (~> 0.81.0)
+  rubocop (~> 0.83.0)
   rubocop-rails
   simplecov-lcov
   solargraph

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'pry-rescue'
   s.add_development_dependency 'rails_email_validator'
-  s.add_development_dependency 'rubocop', '~> 0.81.0' # NOTE: also update .codeclimate.yml and make sure it uses the same version
+  s.add_development_dependency 'rubocop', '~> 0.83.0' # NOTE: also update .codeclimate.yml and make sure it uses the same version
   s.add_development_dependency 'rubocop-rails'
   s.add_development_dependency 'simplecov-lcov'
   s.add_development_dependency 'solargraph'

--- a/test/dummy/app/controllers/widgets_controller.rb
+++ b/test/dummy/app/controllers/widgets_controller.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 class WidgetsController < ApplicationController
   before_action :authenticate_user!
+
   def show
     render plain: 'success'
   end

--- a/test/dummy/app/models/application_user_record.rb
+++ b/test/dummy/app/models/application_user_record.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 if DEVISE_ORM == :active_record
-  class ApplicationUserRecord < ActiveRecord::Base
+  class ApplicationUserRecord < ApplicationRecord
     self.table_name = 'users'
   end
 else

--- a/test/dummy/app/models/mongoid/confirmable_fields.rb
+++ b/test/dummy/app/models/mongoid/confirmable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfirmableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/database_authenticable_fields.rb
+++ b/test/dummy/app/models/mongoid/database_authenticable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DatabaseAuthenticatableFields
   extend ::ActiveSupport::Concern
 
@@ -6,10 +8,9 @@ module DatabaseAuthenticatableFields
 
     ## Database authenticatable
     field :username, type: String
-    field :email, type: String, default: ""
-    #validates_presence_of :email
+    field :email, type: String, default: ''
 
-    field :encrypted_password, type: String, default: ""
+    field :encrypted_password, type: String, default: ''
     validates_presence_of :encrypted_password
 
     include Mongoid::Timestamps

--- a/test/dummy/app/models/mongoid/expirable_fields.rb
+++ b/test/dummy/app/models/mongoid/expirable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ExpirableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/lockable_fields.rb
+++ b/test/dummy/app/models/mongoid/lockable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module LockableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/mappings.rb
+++ b/test/dummy/app/models/mongoid/mappings.rb
@@ -1,11 +1,13 @@
-Dir[File.expand_path("*_fields.rb", __dir__)].each { |f| require_relative f }
+# frozen_string_literal: true
+
+Dir[File.expand_path('*_fields.rb', __dir__)].each { |f| require_relative f }
 
 module Mongoid
   module Mappings
     extend ::ActiveSupport::Concern
 
     included do
-      self.devise_modules.each do |devise_module_name|
+      devise_modules.each do |devise_module_name|
         include "#{devise_module_name.to_s.classify}Fields".constantize
       end
     end

--- a/test/dummy/app/models/mongoid/omniauthable_fields.rb
+++ b/test/dummy/app/models/mongoid/omniauthable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OmniauthableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/paranoid_verification_fields.rb
+++ b/test/dummy/app/models/mongoid/paranoid_verification_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParanoidVerificationFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/password_archivable_fields.rb
+++ b/test/dummy/app/models/mongoid/password_archivable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PasswordArchivableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/password_expirable_fields.rb
+++ b/test/dummy/app/models/mongoid/password_expirable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PasswordExpirableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/recoverable_fields.rb
+++ b/test/dummy/app/models/mongoid/recoverable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RecoverableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/registerable_fields.rb
+++ b/test/dummy/app/models/mongoid/registerable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RegisterableFields
   extend ::ActiveSupport::Concern
 
@@ -5,10 +7,10 @@ module RegisterableFields
     include Mongoid::Document
 
     ## Database authenticatable
-    field :email, type: String, default: ""
+    field :email, type: String, default: ''
     validates_presence_of :email
 
-    field :encrypted_password, type: String, default: ""
+    field :encrypted_password, type: String, default: ''
     validates_presence_of :encrypted_password
 
     field :password_changed_at, type: Time

--- a/test/dummy/app/models/mongoid/rememberable_fields.rb
+++ b/test/dummy/app/models/mongoid/rememberable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RememberableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/secure_validatable_fields.rb
+++ b/test/dummy/app/models/mongoid/secure_validatable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SecureValidatableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/security_questionable_fields.rb
+++ b/test/dummy/app/models/mongoid/security_questionable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SecurityQuestionableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/session_limitable_fields.rb
+++ b/test/dummy/app/models/mongoid/session_limitable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SessionLimitableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/timeoutable_fields.rb
+++ b/test/dummy/app/models/mongoid/timeoutable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TimeoutableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/trackable_fields.rb
+++ b/test/dummy/app/models/mongoid/trackable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TrackableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/mongoid/validatable_fields.rb
+++ b/test/dummy/app/models/mongoid/validatable_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ValidatableFields
   extend ::ActiveSupport::Concern
 

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-
   devise :database_authenticatable,
          :confirmable,
          :expirable,

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -4,7 +4,5 @@ class Widget < ApplicationRecord
   belongs_to :user
   validates_associated :user
 
-  if DEVISE_ORM == :mongoid
-    field :name, type: String
-  end
+  field :name, type: String if DEVISE_ORM == :mongoid
 end

--- a/test/dummy/app/mongoid/one_user.rb
+++ b/test/dummy/app/mongoid/one_user.rb
@@ -11,16 +11,16 @@ class OneUser
   field :password_changed_at, type: Time
   index({ password_changed_at: 1 }, {})
 
-  #field :paranoid_verification_code, type: String
-  #field :paranoid_verified_at, type: Time
-  #field :paranoid_verification_attempt, type: Integer, default: 0
+  field :paranoid_verification_code, type: String
+  field :paranoid_verified_at, type: Time
+  field :paranoid_verification_attempt, type: Integer, default: 0
 
   field :username, type: String
   field :facebook_token, type: String
 
   ## Database authenticatable
-  field :email,              type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field :email,              type: String, default: ''
+  field :encrypted_password, type: String, default: ''
 
   ## Recoverable
   field :reset_password_token,   type: String

--- a/test/dummy/app/mongoid/user_on_engine.rb
+++ b/test/dummy/app/mongoid/user_on_engine.rb
@@ -11,8 +11,8 @@ class UserOnEngine
   field :facebook_token, type: String
 
   ## Database authenticatable
-  field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field :email, type: String, default: ''
+  field :encrypted_password, type: String, default: ''
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/dummy/app/mongoid/user_on_main_app.rb
+++ b/test/dummy/app/mongoid/user_on_main_app.rb
@@ -11,8 +11,8 @@ class UserOnMainApp
   field :facebook_token, type: String
 
   ## Database authenticatable
-  field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field :email, type: String, default: ''
+  field :encrypted_password, type: String, default: ''
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/dummy/app/mongoid/user_with_validations.rb
+++ b/test/dummy/app/mongoid/user_with_validations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "shared_user"
+require 'shared_user'
 
 class UserWithValidations
   include Mongoid::Document
@@ -11,8 +11,8 @@ class UserWithValidations
   field :facebook_token, type: String
 
   ## Database authenticatable
-  field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field :email, type: String, default: ''
+  field :encrypted_password, type: String, default: ''
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/dummy/app/mongoid/user_without_email.rb
+++ b/test/dummy/app/mongoid/user_without_email.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "shared_user_without_email"
+require 'shared_user_without_email'
 
 class UserWithoutEmail
   include Mongoid::Document
@@ -11,8 +11,8 @@ class UserWithoutEmail
   field :facebook_token, type: String
 
   ## Database authenticatable
-  field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field :email, type: String, default: ''
+  field :encrypted_password, type: String, default: ''
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require File.expand_path('../boot', __FILE__)
+require File.expand_path('boot', __dir__)
 
 require 'action_mailer/railtie'
-require "action_mailer/railtie"
-require "rails/test_unit/railtie"
+require 'action_mailer/railtie'
+require 'rails/test_unit/railtie'
 DEVISE_ORM = ENV.fetch('DEVISE_ORM', 'active_record').to_sym
 
 Bundler.require :default, DEVISE_ORM
@@ -25,6 +25,6 @@ module RailsApp
     config.assets.enabled = true
 
     config.assets.version = '1.0'
-    config.secret_key_base = 'fuuuuuuuuuuu'
+    config.secret_key_base = 'foobar'
   end
 end

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -3,6 +3,6 @@
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Load the rails application
-require File.expand_path('../application', __FILE__)
+require File.expand_path('application', __dir__)
 
 # Initialize the rails application
 RailsApp::Application.initialize!

--- a/test/dummy/db/migrate/20120508165529_create_tables.rb
+++ b/test/dummy/db/migrate/20120508165529_create_tables.rb
@@ -33,10 +33,10 @@ class CreateTables < MIGRATION_CLASS
     end
 
     create_table :old_passwords do |t|
-      t.string :encrypted_password, :null => false
+      t.string :encrypted_password, null: false
       t.string :password_salt
-      t.string :password_archivable_type, :null => false
-      t.integer :password_archivable_id, :null => false
+      t.string :password_archivable_type, null: false
+      t.integer :password_archivable_id, null: false
       t.datetime :created_at
     end
     add_index :old_passwords, [:password_archivable_type, :password_archivable_id], name: 'index_password_archivable'

--- a/test/dummy/lib/shared_expirable_columns.rb
+++ b/test/dummy/lib/shared_expirable_columns.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'shared_user'
 
 module SharedVerificationColumns

--- a/test/dummy/lib/shared_security_questions_fields.rb
+++ b/test/dummy/lib/shared_security_questions_fields.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'shared_user'
 
 module SharedSecurityQuestionsFields

--- a/test/dummy/lib/shared_user.rb
+++ b/test/dummy/lib/shared_user.rb
@@ -4,10 +4,21 @@ module SharedUser
   extend ActiveSupport::Concern
 
   included do
-    devise :database_authenticatable, :confirmable, :lockable, :recoverable,
-           :registerable, :rememberable, :timeoutable,
-           :trackable, :secure_validatable, :omniauthable, :validatable, password_length: 7..72,
-           reconfirmable: false
+    devise(
+      :database_authenticatable,
+      :confirmable,
+      :lockable,
+      :recoverable,
+      :registerable,
+      :rememberable,
+      :timeoutable,
+      :trackable,
+      :secure_validatable,
+      :omniauthable,
+      :validatable,
+      password_length: 7..72,
+      reconfirmable: false
+    )
 
     attr_accessor :other_key
 
@@ -22,8 +33,8 @@ module SharedUser
   module ExtendMethods
     def new_with_session(params, session)
       super.tap do |user|
-        if data = session["devise.facebook_data"]
-          user.email = data["email"]
+        if (data = session['devise.facebook_data'])
+          user.email = data['email']
           user.confirmed_at = Time.zone.now
         end
       end

--- a/test/dummy/lib/shared_user_without_email.rb
+++ b/test/dummy/lib/shared_user_without_email.rb
@@ -21,8 +21,9 @@ module SharedUserWithoutEmail
     raise NoMethodError
   end
 
-  def respond_to?(method_name, include_all=false)
+  def respond_to?(method_name, include_all = false)
     return false if method_name.to_sym == :email_changed?
+
     super(method_name, include_all)
   end
 end

--- a/test/dummy/lib/shared_user_without_omniauth.rb
+++ b/test/dummy/lib/shared_user_without_omniauth.rb
@@ -4,9 +4,18 @@ module SharedUserWithoutOmniauth
   extend ActiveSupport::Concern
 
   included do
-    devise :database_authenticatable, :confirmable, :lockable, :recoverable,
-      :registerable, :rememberable, :timeoutable,
-      :trackable, :validatable, reconfirmable: false
+    devise(
+      :database_authenticatable,
+      :confirmable,
+      :lockable,
+      :recoverable,
+      :registerable,
+      :rememberable,
+      :timeoutable,
+      :trackable,
+      :validatable,
+      reconfirmable: false
+    )
   end
 
   def raw_confirmation_token

--- a/test/dummy/lib/shared_verification_fields.rb
+++ b/test/dummy/lib/shared_verification_fields.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'shared_user'
 
 module SharedVerificationFields

--- a/test/integration/test_session_limitable_workflow.rb
+++ b/test/integration/test_session_limitable_workflow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestSessionLimitableWorkflow < ActionDispatch::IntegrationTest

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 require 'active_record'
 
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Base.logger = Logger.new(nil)
-case
-when Rails.gem_version >= Gem::Version.new('6.0.0')
-  ActiveRecord::MigrationContext.new(File.expand_path('../../dummy/db/migrate', __FILE__), ActiveRecord::SchemaMigration).migrate
-when Rails.gem_version >= Gem::Version.new('5.2.0')
-  ActiveRecord::MigrationContext.new(File.expand_path('../../dummy/db/migrate', __FILE__)).migrate
+
+if Rails.gem_version >= Gem::Version.new('6.0.0')
+  ActiveRecord::MigrationContext.new(File.expand_path('../dummy/db/migrate', __dir__), ActiveRecord::SchemaMigration).migrate
+elsif Rails.gem_version >= Gem::Version.new('5.2.0')
+  ActiveRecord::MigrationContext.new(File.expand_path('../dummy/db/migrate', __dir__)).migrate
 end
 
 DatabaseCleaner[:active_record].strategy = :transaction

--- a/test/test_compatibility.rb
+++ b/test/test_compatibility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestCompatibility < ActiveSupport::TestCase

--- a/test/test_complexity_validator.rb
+++ b/test/test_complexity_validator.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
-class PasswordComplexityValidatorTest < Minitest::Test
+class PasswordComplexityValidatorTest < ActiveSupport::TestCase
   class ModelWithPassword
     include ActiveModel::Validations
 
@@ -21,52 +23,52 @@ class PasswordComplexityValidatorTest < Minitest::Test
 
   def test_enforces_uppercase
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { upper: 1 }
-    refute(ModelWithPassword.new('aaaa').valid?)
+    assert_not(ModelWithPassword.new('aaaa').valid?)
     assert(ModelWithPassword.new('Aaaa').valid?)
   end
 
   def test_enforces_count
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { upper: 2 }
-    refute(ModelWithPassword.new('Aaaa').valid?)
+    assert_not(ModelWithPassword.new('Aaaa').valid?)
     assert(ModelWithPassword.new('AAaa').valid?)
   end
 
   def test_enforces_digit
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { digit: 1 }
-    refute(ModelWithPassword.new('aaaa').valid?)
+    assert_not(ModelWithPassword.new('aaaa').valid?)
     assert(ModelWithPassword.new('aaa1').valid?)
   end
 
   def test_enforces_digits
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { digits: 2 }
-    refute(ModelWithPassword.new('aaa1').valid?)
+    assert_not(ModelWithPassword.new('aaa1').valid?)
     assert(ModelWithPassword.new('aa12').valid?)
   end
 
   def test_enforces_lower
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { lower: 1 }
-    refute(ModelWithPassword.new('AAAA').valid?)
+    assert_not(ModelWithPassword.new('AAAA').valid?)
     assert(ModelWithPassword.new('AAAa').valid?)
   end
 
   def test_enforces_symbol
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { symbol: 1 }
-    refute(ModelWithPassword.new('aaaa').valid?)
+    assert_not(ModelWithPassword.new('aaaa').valid?)
     assert(ModelWithPassword.new('aaa!').valid?)
   end
 
   def test_enforces_symbols
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { symbols: 2 }
-    refute(ModelWithPassword.new('aaa!').valid?)
+    assert_not(ModelWithPassword.new('aaa!').valid?)
     assert(ModelWithPassword.new('aa!?').valid?)
   end
 
   def test_enforces_combination
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { lower: 1, upper: 1, digit: 1, symbol: 1 }
-    refute(ModelWithPassword.new('abcd').valid?)
-    refute(ModelWithPassword.new('ABCD').valid?)
-    refute(ModelWithPassword.new('1234').valid?)
-    refute(ModelWithPassword.new('$!,*').valid?)
+    assert_not(ModelWithPassword.new('abcd').valid?)
+    assert_not(ModelWithPassword.new('ABCD').valid?)
+    assert_not(ModelWithPassword.new('1234').valid?)
+    assert_not(ModelWithPassword.new('$!,*').valid?)
     assert(ModelWithPassword.new('aB3*').valid?)
   end
 end

--- a/test/test_install_generator.rb
+++ b/test/test_install_generator.rb
@@ -6,7 +6,7 @@ require 'generators/devise_security/install_generator'
 
 class TestInstallGenerator < Rails::Generators::TestCase
   tests DeviseSecurity::Generators::InstallGenerator
-  destination File.expand_path('../tmp', __FILE__)
+  destination File.expand_path('tmp', __dir__)
   setup :prepare_destination
 
   test 'Assert all files are properly created' do

--- a/test/test_paranoid_verification.rb
+++ b/test/test_paranoid_verification.rb
@@ -94,7 +94,6 @@ class TestParanoidVerification < ActiveSupport::TestCase
     Devise.paranoid_code_regenerate_after_attempt = original_regenerate
   end
 
-
   test 'by default paranoid code regenerate should have 10 attempts' do
     user = User.new(paranoid_verification_code: 'abcde')
     assert_equal 10, user.paranoid_attempts_remaining

--- a/test/test_password_archivable.rb
+++ b/test/test_password_archivable.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class TestPasswordArchivable < ActiveSupport::TestCase
-
   setup do
     Devise.password_archiving_count = 2
   end
@@ -20,7 +19,7 @@ class TestPasswordArchivable < ActiveSupport::TestCase
 
   test 'cannot use same password' do
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
-    assert_raises(ORMInvalidRecordException) { set_password(user,  'Password1') }
+    assert_raises(ORMInvalidRecordException) { set_password(user, 'Password1') }
   end
 
   test 'indirectly saving associated user does not cause deprecation warning' do
@@ -43,19 +42,19 @@ class TestPasswordArchivable < ActiveSupport::TestCase
 
     user = User.create! email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
     assert_equal 0, OldPassword.count
-    set_password(user,  'Password2')
+    set_password(user, 'Password2')
     assert_equal 1, OldPassword.count
 
-    assert_raises(ORMInvalidRecordException) { set_password(user,  'Password1') }
-    set_password(user,  'Password3')
+    assert_raises(ORMInvalidRecordException) { set_password(user, 'Password1') }
+    set_password(user, 'Password3')
     assert_equal 2, OldPassword.count
 
     # rotate first password out of archive
-    assert set_password(user,  'Password4')
+    assert set_password(user, 'Password4')
 
     # archive count was 2, so first password should work again
-    assert set_password(user,  'Password1')
-    assert set_password(user,  'Password2')
+    assert set_password(user, 'Password1')
+    assert set_password(user, 'Password2')
   end
 
   test 'the option should be dynamic during runtime' do
@@ -67,11 +66,11 @@ class TestPasswordArchivable < ActiveSupport::TestCase
 
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
 
-    assert set_password(user,  'Password2')
+    assert set_password(user, 'Password2')
 
-    assert_raises(ORMInvalidRecordException) { set_password(user,  'Password2') }
+    assert_raises(ORMInvalidRecordException) { set_password(user, 'Password2') }
 
-    assert_raises(ORMInvalidRecordException) { set_password(user,  'Password1') }
+    assert_raises(ORMInvalidRecordException) { set_password(user, 'Password1') }
   end
 
   test 'default sort orders do not affect archiving' do
@@ -83,18 +82,18 @@ class TestPasswordArchivable < ActiveSupport::TestCase
 
     user = User.create! email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
     assert_equal 0, OldPassword.count
-    set_password(user,  'Password2')
+    set_password(user, 'Password2')
     assert_equal 1, OldPassword.count
 
-    assert_raises(ORMInvalidRecordException) { set_password(user,  'Password1') }
-    set_password(user,  'Password3')
+    assert_raises(ORMInvalidRecordException) { set_password(user, 'Password1') }
+    set_password(user, 'Password3')
     assert_equal 2, OldPassword.count
 
     # rotate first password out of archive
-    assert set_password(user,  'Password4')
+    assert set_password(user, 'Password4')
 
     # archive count was 2, so first password should work again
-    assert set_password(user,  'Password1')
-    assert set_password(user,  'Password2')
+    assert set_password(user, 'Password1')
+    assert set_password(user, 'Password2')
   end
 end

--- a/test/test_password_expirable.rb
+++ b/test/test_password_expirable.rb
@@ -14,59 +14,59 @@ class TestPasswordArchivable < ActiveSupport::TestCase
   test 'does nothing if disabled' do
     Devise.expire_password_after = false
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
-    refute user.need_change_password?
-    refute user.password_expired?
+    assert_not user.need_change_password?
+    assert_not user.password_expired?
     user.need_change_password!
-    refute user.need_change_password?
-    refute user.password_expired?
+    assert_not user.need_change_password?
+    assert_not user.password_expired?
   end
 
   test 'password change can be requested' do
     Devise.expire_password_after = true
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
-    refute user.need_change_password?
-    refute user.password_expired?
-    refute user.password_change_requested?
+    assert_not user.need_change_password?
+    assert_not user.password_expired?
+    assert_not user.password_change_requested?
     user.need_change_password!
     assert user.need_change_password?
-    refute user.password_expired? # it's not too old because it's not set at all
+    assert_not user.password_expired? # it's not too old because it's not set at all
     assert user.password_change_requested?
   end
 
   test 'password expires' do
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
-    refute user.need_change_password?
-    refute user.password_expired?
-    refute user.password_too_old?
-    user.update(password_changed_at: Time.now.ago(3.months))
+    assert_not user.need_change_password?
+    assert_not user.password_expired?
+    assert_not user.password_too_old?
+    user.update(password_changed_at: Time.zone.now.ago(3.months))
     assert user.password_too_old?
     assert user.need_change_password?
     assert user.password_expired?
-    refute user.password_change_requested?
+    assert_not user.password_change_requested?
   end
 
   test 'saving a record records the time the password was changed' do
     user = User.new email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
     assert user.password_changed_at.nil?
-    refute user.password_change_requested?
-    refute user.password_expired?
+    assert_not user.password_change_requested?
+    assert_not user.password_expired?
     user.save
     assert user.password_changed_at.present?
-    refute user.password_change_requested?
-    refute user.password_expired?
+    assert_not user.password_change_requested?
+    assert_not user.password_expired?
   end
 
   test 'updating a record updates the time the password was changed if the password is changed' do
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
-    user.update(password_changed_at: Time.now.ago(3.months))
+    user.update(password_changed_at: Time.zone.now.ago(3.months))
     original_password_changed_at = user.password_changed_at
     user.expire_password!
     assert user.password_change_requested?
-    user.password = "NewPassword1"
-    user.password_confirmation = "NewPassword1"
+    user.password = 'NewPassword1'
+    user.password_confirmation = 'NewPassword1'
     user.save
     assert user.password_changed_at > original_password_changed_at
-    refute user.password_change_requested?
+    assert_not user.password_change_requested?
   end
 
   test 'updating a record does not updates the time the password was changed if the password was not changed' do
@@ -74,7 +74,7 @@ class TestPasswordArchivable < ActiveSupport::TestCase
     user.expire_password!
     assert user.password_change_requested?
     user.save
-    refute user.previous_changes.key?(:password_changed_at)
+    assert_not user.previous_changes.key?(:password_changed_at)
     assert user.password_change_requested?
   end
 
@@ -85,10 +85,10 @@ class TestPasswordArchivable < ActiveSupport::TestCase
         4.months
       end
     end
-    user.password_changed_at = Time.now.ago(3.months)
-    refute user.need_change_password?
-    refute user.password_expired?
-    user.password_changed_at = Time.now.ago(5.months)
+    user.password_changed_at = Time.zone.now.ago(3.months)
+    assert_not user.need_change_password?
+    assert_not user.password_expired?
+    user.password_changed_at = Time.zone.now.ago(5.months)
     assert user.need_change_password?
     assert user.password_expired?
   end

--- a/test/test_session_limitable.rb
+++ b/test/test_session_limitable.rb
@@ -18,7 +18,7 @@ class TestSessionLimitable < ActiveSupport::TestCase
     modified_user = ModifiedUser.create email: 'bob2@microsoft.com', password: 'password1', password_confirmation: 'password1'
     assert_equal(true, modified_user.skip_session_limitable?)
   end
-    
+
   class SessionLimitableUser < User
     devise :session_limitable
     include ::Mongoid::Mappings if DEVISE_ORM == :mongoid
@@ -51,7 +51,7 @@ class TestSessionLimitable < ActiveSupport::TestCase
 
   test '#update_unique_session_id!(value) raises an exception on an unpersisted record' do
     user = User.create
-    assert !user.persisted?
+    assert_not user.persisted?
     assert_raises(Devise::Models::Compatibility::NotPersistedError) { user.update_unique_session_id!('unique_value') }
   end
 end


### PR DESCRIPTION
Also turns on rubocop for the test suite code because it was a big mess.

Based on https://github.com/devise-security/devise-security/pull/183

Co-authored-by Kevin Olbrich <kevin.olbrich@gmail.com>