### PR TITLE
Only show 'blank' error if password is missing

### DIFF
--- a/lib/devise-security/models/secure_validatable.rb
+++ b/lib/devise-security/models/secure_validatable.rb
@@ -44,7 +44,9 @@ module Devise
               validates :email, uniqueness: true, allow_blank: true, if: :email_changed? # check uniq for email ever
             end
 
-            validates :password, presence: true, length: password_length, confirmation: true, if: :password_required?
+            validates_presence_of :password, if: :password_required?
+            validates_confirmation_of :password, if: :password_required?
+            validates_length_of :password, within: password_length, allow_blank: true
           end
 
           # extra validations

--- a/lib/devise-security/validators/password_complexity_validator.rb
+++ b/lib/devise-security/validators/password_complexity_validator.rb
@@ -19,6 +19,8 @@ class DeviseSecurity::PasswordComplexityValidator < ActiveModel::EachValidator
   }.freeze
 
   def validate_each(record, attribute, value)
+    return unless value.present?
+
     active_pattern_keys.each do |key|
       minimum = [0, options[key].to_i].max
       pattern = Regexp.new PATTERNS[key]

--- a/test/test_complexity_validator.rb
+++ b/test/test_complexity_validator.rb
@@ -21,6 +21,11 @@ class PasswordComplexityValidatorTest < ActiveSupport::TestCase
     assert(ModelWithPassword.new('aaaa').valid?)
   end
 
+  def test_allows_blank
+    ModelWithPassword.validates :password, 'devise_security/password_complexity': { upper: 1 }
+    assert(ModelWithPassword.new('').valid?)
+  end
+
   def test_enforces_uppercase
     ModelWithPassword.validates :password, 'devise_security/password_complexity': { upper: 1 }
     assert_not(ModelWithPassword.new('aaaa').valid?)

--- a/test/test_secure_validatable.rb
+++ b/test/test_secure_validatable.rb
@@ -91,13 +91,7 @@ class TestSecureValidatable < ActiveSupport::TestCase
   test 'password cannot be blank upon creation' do
     user = User.new(email: 'bob@microsoft.com')
 
-    msgs = [
-      "Password can't be blank",
-      'Password is too short (minimum is 7 characters)',
-      'Password must contain at least one digit',
-      'Password must contain at least one lower-case letter',
-      'Password must contain at least one upper-case letter'
-    ]
+    msgs = ["Password can't be blank"]
 
     msgs << "Encrypted password can't be blank" if DEVISE_ORM == :mongoid
 
@@ -118,16 +112,7 @@ class TestSecureValidatable < ActiveSupport::TestCase
     user.password_confirmation = nil
 
     assert user.invalid?
-    assert_equal(
-      [
-        "Password can't be blank",
-        'Password is too short (minimum is 7 characters)',
-        'Password must contain at least one digit',
-        'Password must contain at least one lower-case letter',
-        'Password must contain at least one upper-case letter'
-      ],
-      user.errors.full_messages
-    )
+    assert_equal(["Password can't be blank"],user.errors.full_messages)
   end
 
   test 'password_confirmation must match password' do


### PR DESCRIPTION
Changes to `secure_validatable` were copied directly from the devise
`validatable` module.

Closes https://github.com/devise-security/devise-security/issues/322