### PR TITLE
Fix for Simplecov.start in Ruby 3.1

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,13 @@
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'simplecov'
+
+if ENV['CI']
+  require 'simplecov-lcov'
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+end
+
 SimpleCov.start do
   add_filter 'gemfiles'
   add_filter 'test/dummy/db'
@@ -16,14 +23,6 @@ SimpleCov.start do
   add_group 'Security Questionable', 'security_question'
   add_group 'Session Limitable', 'session_limitable'
   add_group 'Tests', 'test'
-end
-
-if ENV['CI']
-  require 'simplecov'
-  require 'simplecov-lcov'
-  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
-  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-  SimpleCov.start
 end
 
 require 'pry'


### PR DESCRIPTION
Starting in 3.1, the Ruby `Coverage` module will throw an error if you
call `Coverage.start` more than once. This commit cleans up the config
so that we only ever call `Coverage.start` once.

See https://github.com/ruby/ruby/pull/4856/files#diff-4fd3567b713b460fa5616259e35ab22faaa28376ea929ce0254744d6e16ffd33R78