### PR TITLE
Disable mongoid on ruby head

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -14,6 +14,13 @@ jobs:
         orm: [active_record, mongoid]
         rails: ["5.2", "6.0", "6.1"]
         ruby: ["2.6", "2.7", "3.0", head]
+        exclude:
+          - orm: mongoid
+            rails: 6.0
+            ruby: head
+          - orm: mongoid
+            rails: 6.1
+            ruby: head
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -21,6 +21,10 @@ jobs:
           - orm: mongoid
             rails: 6.1
             ruby: head
+          - rails: 5.2
+            ruby: 3.0
+          - rails: 5.2
+            ruby: head
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -41,9 +45,6 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install
-        # Rails < 5.2 is not compatible with Ruby 3.0
-        if:
-          ${{ !(matrix.rails < '6.0' && matrix.ruby >= '3.0' ) }}
       - name: Start MongoDB
         uses: superchargejs/mongodb-github-action@1.0.0
         if: ${{ matrix.orm == 'mongoid' }}
@@ -56,9 +57,6 @@ jobs:
           DEVISE_ORM: ${{ matrix.orm }}
         run: |
           bundle exec rake
-        # Rails < 5.2 is not compatible with Ruby 3.0
-        if:
-          ${{ !(matrix.rails < '6.0' && matrix.ruby >= '3.0' ) }}
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
         with:
@@ -68,9 +66,6 @@ jobs:
             matrix.ruby }}
           parallel: true
           path-to-lcov: ./coverage/lcov/devise-security.lcov
-        # Rails < 5.2 is not compatible with Ruby 3.0
-        if:
-          ${{ !(matrix.rails < '6.0' && matrix.ruby >= '3.0' ) }}
 
   finish:
     needs: run-tests


### PR DESCRIPTION
Closes https://github.com/devise-security/devise-security/issues/344

Looks like mongoid and ruby-head aren't cooperating. Made https://github.com/devise-security/devise-security/issues/347 to address this later.

Not only does this clean up the config file, but the tests doesn't even get queued up on Github. This is vastly better than the previous approach, which queued up the jobs and they just completed really quickly.