### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-rails
+  - rubocop-minitest
 
 AllCops:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    regexp_parser (2.2.0)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -203,17 +204,23 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    rubocop (0.83.0)
+    rubocop (1.24.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
+      rubocop-ast (>= 1.15.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-rails (2.5.2)
-      activesupport
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.15.1)
+      parser (>= 3.0.1.1)
+    rubocop-minitest (0.17.0)
+      rubocop (>= 0.90, < 2.0)
+    rubocop-rails (2.13.0)
+      activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 0.72.0)
+      rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     simplecov (0.21.2)
@@ -254,7 +261,7 @@ GEM
     tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    unicode-display_width (1.8.0)
+    unicode-display_width (2.1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     webrick (1.7.0)
@@ -285,7 +292,8 @@ DEPENDENCIES
   rails-controller-testing
   rails_email_validator
   railties (~> 5.2.6)
-  rubocop (~> 0.83.0)
+  rubocop
+  rubocop-minitest
   rubocop-rails
   simplecov-lcov
   solargraph
@@ -293,4 +301,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.33
+   2.3.3

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -37,7 +37,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'pry-rescue'
   s.add_development_dependency 'rails_email_validator'
-  s.add_development_dependency 'rubocop', '~> 0.83.0' # NOTE: also update .codeclimate.yml and make sure it uses the same version
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-minitest'
   s.add_development_dependency 'rubocop-rails'
   s.add_development_dependency 'simplecov-lcov'
   s.add_development_dependency 'solargraph'


### PR DESCRIPTION
* Removes version constraint on Rubocop
* Add rubocop-minitest

I deliberately did not apply any rubocop auto corrections in this branch. There are a lot of them and not all of them are correct or desirable, so we should do those in smaller batches.