### PR TITLE
Add paranoid verfication config for devise_security.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Devise.setup do |config|
 
   # Allow passwords to be equal to email (false, true)
   # config.allow_passwords_equal_to_email = false
+
+  # paranoid_verification will regenerate verification code after failed attempt
+  # config.paranoid_code_regenerate_after_attempt = 10
 end
 ```
 

--- a/lib/generators/templates/devise_security.rb
+++ b/lib/generators/templates/devise_security.rb
@@ -44,4 +44,7 @@ Devise.setup do |config|
 
   # Allow password to equal the email
   # config.allow_passwords_equal_to_email = false
+
+  # paranoid_verification will regenerate verification code after failed attempt
+  # config.paranoid_code_regenerate_after_attempt = 10
 end


### PR DESCRIPTION
## WHAT

 - Add paranoid verfication config for devise_security.rb

## WHY

- because there was no description about paranoid_code_regenerate_after_attempt in devise_security.rb.

## ATTENTION

- This is my first time to make a pull request, so I would appreciate it if you could point out any missing items.