### PR TITLE
PasswordExpiredController: Accept block for update action

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -20,7 +20,11 @@ class Devise::PasswordExpiredController < DeviseController
   # @see https://github.com/devise-security/devise-security/pull/111
   def update
     resource.extend(Devise::Models::DatabaseAuthenticatablePatch)
-    if resource.update_with_password(resource_params)
+    resource.update_with_password(resource_params)
+
+    yield resource if block_given?
+
+    if resource.errors.empty?
       warden.session(scope)['password_expired'] = false
       set_flash_message :notice, :updated
       bypass_sign_in resource, scope: scope

--- a/test/controllers/test_password_expired_controller.rb
+++ b/test/controllers/test_password_expired_controller.rb
@@ -156,4 +156,9 @@ class PasswordExpiredCustomRedirectTest < ActionController::TestCase
 
     assert_redirected_to '/cookies'
   end
+
+  test 'yield resource to block on update' do
+    put(:update, params: { password_expired_user: { current_password: '123' } })
+    assert @controller.update_block_called?, 'Update failed to yield resource to provided block'
+  end
 end

--- a/test/dummy/app/controllers/overrides/password_expired_controller.rb
+++ b/test/dummy/app/controllers/overrides/password_expired_controller.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 class Overrides::PasswordExpiredController < Devise::PasswordExpiredController
+  def update
+    super do |resource|
+      @update_block_called = true
+    end
+  end
+
   def after_password_expired_update_path_for(_)
     '/cookies'
+  end
+
+  def update_block_called?
+    @update_block_called == true
   end
 end


### PR DESCRIPTION
Currently if password is failed to update, nothing is displayed, and there is no way to change it easily (ie. without completely overriding `update` action in app's controller)

Devise though, allows user to add additional logic by passing a block to the `update`, like here: https://github.com/heartcombo/devise/blob/8593801130f2df94a50863b5db535c272b00efe1/app/controllers/devise/passwords_controller.rb#L34-L37

In this PR we're using same pattern.

So now user can do something like this:

```ruby
class Users::PasswordExpiredController < Devise::PasswordExpiredController
  def update
    super do |resource|
      flash[:error] = resource.errors.full_messages.first if resource.errors.any?
    end
  end
end
```