### PR TITLE
Lock down ruby version

### DIFF
--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['README.md', 'LICENSE.txt', 'lib/**/*', 'app/**/*', 'config/**/*']
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency 'devise', '>= 4.3.0'
 


### PR DESCRIPTION
I noticed that my app that is currently running Ruby 2.6 was able to be updated to the lates release. Only tested versions should be able to be updated.