### PR TITLE
Add `required_fields` models method

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         orm: [active_record, mongoid]
         rails: ["5.2", "6.0", "6.1", "7.0"]
-        ruby: ["2.7", "3.0", "3.1", "3.2", head]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", head]
         exclude:
           - rails: 5.2
             ruby: 3.0
@@ -21,6 +21,8 @@ jobs:
             ruby: 3.1
           - rails: 5.2
             ruby: 3.2
+          - rails: 5.2
+            ruby: 3.3
           - rails: 5.2
             ruby: head
           - rails: 7.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.18.0, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
+    mutex_m (0.2.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -349,6 +350,7 @@ DEPENDENCIES
   minitest
   minitest-rails (~> 6.0.0)
   mongoid (~> 8.0)
+  mutex_m
   omniauth
   pry-rescue
   rails-controller-testing

--- a/devise-security.gemspec
+++ b/devise-security.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov-lcov'
   s.add_development_dependency 'solargraph'
   s.add_development_dependency 'solargraph-arc'
+  s.add_development_dependency 'mutex_m'
 end

--- a/lib/devise-security/models/expirable.rb
+++ b/lib/devise-security/models/expirable.rb
@@ -20,6 +20,10 @@ module Devise
     module Expirable
       extend ActiveSupport::Concern
 
+      def self.required_fields(_klass)
+        [:last_activity_at, :expired_at]
+      end
+
       # Updates +last_activity_at+, called from a Warden::Manager.after_set_user hook.
       def update_last_activity!
         if respond_to?(:update_column)

--- a/lib/devise-security/models/paranoid_verification.rb
+++ b/lib/devise-security/models/paranoid_verification.rb
@@ -8,6 +8,10 @@ module Devise
     module ParanoidVerification
       extend ActiveSupport::Concern
 
+      def self.required_fields(_klass)
+        [:paranoid_verification_code, :paranoid_verification_attempt, :paranoid_verified_at]
+      end
+
       def need_paranoid_verification?
         !!paranoid_verification_code
       end

--- a/lib/devise-security/models/password_archivable.rb
+++ b/lib/devise-security/models/password_archivable.rb
@@ -19,6 +19,10 @@ module Devise
 
       delegate :present?, to: :password, prefix: true
 
+      def self.required_fields(_klass)
+        []
+      end
+
       def validate_password_archive
         errors.add(:password, :taken_in_past) if will_save_change_to_encrypted_password? && password_archive_included?
       end

--- a/lib/devise-security/models/password_expirable.rb
+++ b/lib/devise-security/models/password_expirable.rb
@@ -25,6 +25,10 @@ module Devise::Models
       before_save :update_password_changed
     end
 
+    def self.required_fields(_klass)
+      [:password_changed_at]
+    end
+
     # Is a password change required?
     # @return [Boolean]
     # @return [true] if +password_changed_at+ has not been set or if it is old

--- a/lib/devise-security/models/secure_validatable.rb
+++ b/lib/devise-security/models/secure_validatable.rb
@@ -82,6 +82,10 @@ module Devise
         raise "Could not use SecureValidatable on #{base}" unless base.respond_to?(:validates)
       end
 
+      def self.required_fields(_klass)
+        []
+      end
+
       def current_equal_password_validation
         return if new_record? || !will_save_change_to_encrypted_password? || password.blank?
 

--- a/lib/devise-security/models/security_questionable.rb
+++ b/lib/devise-security/models/security_questionable.rb
@@ -14,6 +14,10 @@ module Devise
     # f.text_field :security_question_answer
     module SecurityQuestionable
       extend ActiveSupport::Concern
+
+      def self.required_fields(_klass)
+        [:security_question_id, :security_question_answer]
+      end
     end
   end
 end

--- a/lib/devise-security/models/session_limitable.rb
+++ b/lib/devise-security/models/session_limitable.rb
@@ -14,6 +14,10 @@ module Devise
       extend ActiveSupport::Concern
       include Devise::Models::Compatibility
 
+      def self.required_fields(_klass)
+        [:unique_session_id]
+      end
+
       # Update the unique_session_id on the model.  This will be checked in
       # the Warden after_set_user hook in {file:devise-security/hooks/session_limitable}
       # @param unique_session_id [String]

--- a/test/test_expirable.rb
+++ b/test/test_expirable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestExpirable < ActiveSupport::TestCase
+  test 'should have required_fields array' do
+    assert_equal [:last_activity_at, :expired_at], Devise::Models::Expirable.required_fields(User)
+  end
+end

--- a/test/test_paranoid_verification.rb
+++ b/test/test_paranoid_verification.rb
@@ -3,6 +3,13 @@
 require 'test_helper'
 
 class TestParanoidVerification < ActiveSupport::TestCase
+  test 'should have required_fields array' do
+    assert_equal(
+      [:paranoid_verification_attempt, :paranoid_verified_at],
+      Devise::Models::ParanoidVerification.required_fields(User)
+    )
+  end
+
   test 'need to paranoid verify if code present' do
     user = User.new
     user.generate_paranoid_code

--- a/test/test_paranoid_verification.rb
+++ b/test/test_paranoid_verification.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class TestParanoidVerification < ActiveSupport::TestCase
   test 'should have required_fields array' do
     assert_equal(
-      [:paranoid_verification_attempt, :paranoid_verified_at],
+      [:paranoid_verification_code, :paranoid_verification_attempt, :paranoid_verified_at],
       Devise::Models::ParanoidVerification.required_fields(User)
     )
   end

--- a/test/test_password_archivable.rb
+++ b/test/test_password_archivable.rb
@@ -17,6 +17,10 @@ class TestPasswordArchivable < ActiveSupport::TestCase
     user.save!
   end
 
+  test 'required_fields should be an empty array' do
+    assert_empty Devise::Models::PasswordArchivable.required_fields(User)
+  end
+
   test 'cannot use same password' do
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'
     assert_raises(ORMInvalidRecordException) { set_password(user, 'Password1') }

--- a/test/test_password_expirable.rb
+++ b/test/test_password_expirable.rb
@@ -11,6 +11,10 @@ class TestPasswordArchivable < ActiveSupport::TestCase
     Devise.expire_password_after = 90.days
   end
 
+  test 'should have required_fields array' do
+    assert_equal [:password_changed_at], Devise::Models::PasswordExpirable.required_fields(User)
+  end
+
   test 'does nothing if disabled' do
     Devise.expire_password_after = false
     user = User.create email: 'bob@microsoft.com', password: 'Password1', password_confirmation: 'Password1'

--- a/test/test_password_expirable.rb
+++ b/test/test_password_expirable.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class TestPasswordArchivable < ActiveSupport::TestCase
+class TestPasswordExpirable < ActiveSupport::TestCase
   setup do
     Devise.expire_password_after = 2.months
   end

--- a/test/test_secure_validatable.rb
+++ b/test/test_secure_validatable.rb
@@ -16,6 +16,10 @@ class TestSecureValidatable < ActiveSupport::TestCase
     end
   end
 
+  test 'required_fields should be an empty array' do
+    assert_empty Devise::Models::SecureValidatable.required_fields(User)
+  end
+
   test 'email cannot be blank upon creation' do
     user = User.new(
       password: 'Password1!', password_confirmation: 'Password1!'

--- a/test/test_security_questionable.rb
+++ b/test/test_security_questionable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestSecurityQuestionable < ActiveSupport::TestCase
+  test 'should have required_fields array' do
+    assert_equal(
+      [:security_question_id, :security_question_answer],
+      Devise::Models::SecurityQuestionable.required_fields(User)
+    )
+  end
+end

--- a/test/test_session_limitable.rb
+++ b/test/test_session_limitable.rb
@@ -9,6 +9,10 @@ class TestSessionLimitable < ActiveSupport::TestCase
     end
   end
 
+  test 'should have required_fields array' do
+    assert_equal [:unique_session_id], Devise::Models::SessionLimitable.required_fields(User)
+  end
+
   test 'check is not skipped by default' do
     user = User.new(email: 'bob@microsoft.com', password: 'password1', password_confirmation: 'password1')
     assert_not(user.skip_session_limitable?)


### PR DESCRIPTION
### Summary
This PR adds `self.required_fields(Model)` methods to all the models. `Devise::Models.check_fields! Model` calls this method under the hood to verify if the devise model has required columns present or not.

fixes #436 