### PR TITLE
fix: clear unique_session_id when user signs out

### DIFF
--- a/lib/devise-security/hooks/session_limitable.rb
+++ b/lib/devise-security/hooks/session_limitable.rb
@@ -42,3 +42,14 @@ Warden::Manager.after_set_user only: :fetch do |record, warden, options|
     end
   end
 end
+
+# When a user is signing out intentionally, we clear the unique session id
+# to prevent session replay attacks. This ensures there are 0 valid active
+# sessions immediately after signing out.
+Warden::Manager.before_logout do |record, warden, options|
+  if record.nil? == false &&
+     record.devise_modules&.include?(:session_limitable) &&
+     !record.skip_session_limitable?
+    record.update_unique_session_id!(nil)
+  end
+end

--- a/test/integration/test_session_limitable_workflow.rb
+++ b/test/integration/test_session_limitable_workflow.rb
@@ -66,4 +66,21 @@ class TestSessionLimitableWorkflow < ActionDispatch::IntegrationTest
       assert_equal session.flash[:alert], I18n.t('devise.failure.session_limited')
     end
   end
+
+  test 'session is cleared when user logs out' do
+    assert_nil @user.unique_session_id
+
+    open_session do |session|
+      sign_in(@user, session)
+      session.assert_redirected_to '/'
+      session.get widgets_path
+      session.assert_response(:success)
+      assert_equal('success', session.response.body)
+      assert_not_nil @user.reload.unique_session_id
+
+      sign_out(session)
+      session.assert_redirected_to '/'
+      assert_nil @user.reload.unique_session_id
+    end
+  end
 end

--- a/test/support/integration_helpers.rb
+++ b/test/support/integration_helpers.rb
@@ -32,4 +32,11 @@ module IntegrationHelpers
       }
     )
   end
+
+  # logout the user.  This will exercise all the Warden Hooks
+  # @param session [ActionDispatch::Integration::Session]
+  # @return [void]
+  def sign_out(session = integration_session)
+    session.delete(destroy_user_session_path)
+  end
 end


### PR DESCRIPTION
Prevents session replays when application uses a cookie session store.