### PR TITLE
Fix Devise 5 test compatibility and add Devise version CI matrix

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -18,6 +18,7 @@ jobs:
         orm: [active_record, mongoid]
         rails: ["7.0", "7.1", "7.2", "8.0"]
         ruby: ["3.1", "3.2", "3.3", "3.4", head]
+        devise: ["4", "5"]
         exclude:
           - rails: "8.0"
             ruby: "3.1"
@@ -31,13 +32,15 @@ jobs:
           path: |
             **/bundle
           key:
-            bundle-use-ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }}-orm-${{
+            bundle-use-ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }}-devise-${{
+            matrix.devise }}-orm-${{
             matrix.orm }}-gemfile-${{
             hashFiles(format('**/gemfiles/rails_{0}.gemfile', matrix.rails))
             }}-gemspec-${{ hashFiles('**/devise-security.gemspec') }}
       - name: bundle install
         env:
           BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
+          DEVISE_VERSION: ${{ matrix.devise }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libmagickwand-dev
@@ -47,10 +50,11 @@ jobs:
         uses: supercharge/mongodb-github-action@1.11.0
         if: ${{ matrix.orm == 'mongoid' }}
       - name:
-          Tests for ORM ${{ matrix.orm }}, Rails ${{ matrix.rails }}, and Ruby
-          ${{ matrix.ruby }}
+          Tests for ORM ${{ matrix.orm }}, Rails ${{ matrix.rails }}, Devise
+          ${{ matrix.devise }}, and Ruby ${{ matrix.ruby }}
         env:
           BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
+          DEVISE_VERSION: ${{ matrix.devise }}
           CI: true
           DEVISE_ORM: ${{ matrix.orm }}
         run: |
@@ -60,8 +64,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name:
-            run-orm-${{ matrix.orm }}-rails-${{ matrix.rails }}-ruby-${{
-            matrix.ruby }}
+            run-orm-${{ matrix.orm }}-rails-${{ matrix.rails }}-devise-${{
+            matrix.devise }}-ruby-${{ matrix.ruby }}
           parallel: true
           path-to-lcov: ./coverage/lcov/devise-security.lcov
 

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -25,3 +25,10 @@ group :test do
 end
 
 gemspec path: "../"
+
+# Pin Devise version when DEVISE_VERSION is set (used in CI matrix)
+if ENV["DEVISE_VERSION"] == "4"
+  gem "devise", "~> 4.9"
+elsif ENV["DEVISE_VERSION"] == "5"
+  gem "devise", "~> 5.0"
+end

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -25,3 +25,10 @@ group :test do
 end
 
 gemspec path: "../"
+
+# Pin Devise version when DEVISE_VERSION is set (used in CI matrix)
+if ENV["DEVISE_VERSION"] == "4"
+  gem "devise", "~> 4.9"
+elsif ENV["DEVISE_VERSION"] == "5"
+  gem "devise", "~> 5.0"
+end

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -25,3 +25,10 @@ group :test do
 end
 
 gemspec path: "../"
+
+# Pin Devise version when DEVISE_VERSION is set (used in CI matrix)
+if ENV["DEVISE_VERSION"] == "4"
+  gem "devise", "~> 4.9"
+elsif ENV["DEVISE_VERSION"] == "5"
+  gem "devise", "~> 5.0"
+end

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -25,3 +25,10 @@ group :test do
 end
 
 gemspec path: "../"
+
+# Pin Devise version when DEVISE_VERSION is set (used in CI matrix)
+if ENV["DEVISE_VERSION"] == "4"
+  gem "devise", "~> 4.9"
+elsif ENV["DEVISE_VERSION"] == "5"
+  gem "devise", "~> 5.0"
+end

--- a/test/controllers/test_captcha_controller.rb
+++ b/test/controllers/test_captcha_controller.rb
@@ -34,7 +34,7 @@ class TestWithCaptcha < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_equal 'Invalid Email or password.', flash[:alert]
+    assert_match(/invalid.*email.*password/i, flash[:alert])
   end
 end
 
@@ -49,6 +49,6 @@ class TestWithoutCaptcha < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_equal 'Invalid Email or password.', flash[:alert]
+    assert_match(/invalid.*email.*password/i, flash[:alert])
   end
 end

--- a/test/integration/test_session_limitable_workflow.rb
+++ b/test/integration/test_session_limitable_workflow.rb
@@ -18,7 +18,7 @@ class TestSessionLimitableWorkflow < ActionDispatch::IntegrationTest
     open_session do |session|
       failed_sign_in(@user, session)
       session.assert_response(:success)
-      assert_equal session.flash[:alert], I18n.t('devise.failure.invalid', authentication_keys: 'Email')
+      assert_match(/invalid.*email.*password/i, session.flash[:alert])
       assert_nil @user.reload.unique_session_id
     end
   end


### PR DESCRIPTION
## Summary

Devise 5 changed the i18n translation for `devise.failure.invalid` from `"Invalid Email or password."` to `"Invalid email or password."` (lowercase "email"). This causes 3 test failures on main:

- `test/controllers/test_captcha_controller.rb:37` — `TestWithCaptcha`
- `test/controllers/test_captcha_controller.rb:52` — `TestWithoutCaptcha`
- `test/integration/test_session_limitable_workflow.rb:21` — `TestSessionLimitableWorkflow`

## Changes

**Fix test assertions (commit 1):** Replaced exact string assertions (`assert_equal`) with case-insensitive regex assertions (`assert_match(/invalid.*email.*password/i, ...)`) so the tests pass with both Devise 4 and Devise 5. This is the same approach used by the [MITRE fork](https://github.com/MITRE/devise-security).

**Add Devise version CI matrix (commit 2):** Added a `devise: ["4", "5"]` dimension to the CI test matrix so tests explicitly run against both Devise 4 (`~> 4.9`) and Devise 5 (`~> 5.0`). Each Appraisal gemfile conditionally pins the Devise version based on a `DEVISE_VERSION` environment variable set by CI. When unset (e.g., local development), bundler resolves Devise freely as before.